### PR TITLE
Update documentation comment in int2en.py

### DIFF
--- a/int2en/int2en.py
+++ b/int2en/int2en.py
@@ -61,7 +61,7 @@ def _handle_decimal(number):
 def _i2e(str_integer, shift = 0):
     '''
     Given str_integer, a string representation of an integer,
-    Return its the American English written form.
+    Return its American English written form.
     '''
     # pad zeros to the front to make it divisible by 3
     str_integer = _pad_with_zeros(str_integer)


### PR DESCRIPTION
This fix addresses a [grammatical mistake/mismatched behavior/lack of detail] in the comment description.


Background: I'm doing a research study on function comments that may be improvable. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!
